### PR TITLE
fix(ostool): bound U-Boot shell initialization

### DIFF
--- a/ostool/CHANGELOG.md
+++ b/ostool/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(ostool)* bound U-Boot shell initialization when the serial console never responds
+
 ## [0.28.0](https://github.com/drivercraft/ostool/compare/ostool-v0.27.1...ostool-v0.28.0) - 2026-08-20
 
 ### Added

--- a/ostool/src/auth/token_manager.rs
+++ b/ostool/src/auth/token_manager.rs
@@ -74,7 +74,6 @@ impl TokenManager {
             CredentialRecord::OAuthRefresh {
                 access_token,
                 access_expires_at,
-                refresh_token: _,
                 ..
             } if access_expires_at > Utc::now() + Duration::seconds(60) => Ok(Some(access_token)),
             CredentialRecord::OAuthRefresh { refresh_token, .. } => {

--- a/ostool/src/run/uboot.rs
+++ b/ostool/src/run/uboot.rs
@@ -59,6 +59,21 @@ use crate::{
     utils::PathResultExt,
 };
 
+/// Keep a dead serial console from holding a board runner forever when no
+/// positive U-Boot timeout is configured.
+const DEFAULT_UBOOT_SHELL_TIMEOUT: Duration = Duration::from_secs(300);
+
+async fn new_uboot_shell<Tx, Rx>(tx: Tx, rx: Rx, timeout: Duration) -> anyhow::Result<UbootShell>
+where
+    Tx: futures::io::AsyncWrite + Send + Unpin + 'static,
+    Rx: futures::io::AsyncRead + Send + Unpin + 'static,
+{
+    tokio::time::timeout(timeout, UbootShell::new(tx, rx))
+        .await
+        .with_context(|| format!("timed out waiting for U-Boot shell after {timeout:?}"))?
+        .context("failed to initialize U-Boot shell")
+}
+
 #[derive(Debug, Clone, Serialize, JsonSchema, Default)]
 pub struct UbootConfig {
     pub dtb_file: Option<String>,
@@ -83,7 +98,7 @@ pub struct UbootConfig {
     #[serde(default)]
     pub shell_check_steps: Vec<ShellCheckStep>,
     /// Timeout in seconds after entering the serial terminal interaction stage. `None` or `0`
-    /// disables the timeout.
+    /// disables the terminal timeout; U-Boot shell initialization still uses a bounded default.
     pub timeout: Option<u64>,
     #[serde(flatten)]
     pub local: LocalUbootConfig,
@@ -1179,7 +1194,10 @@ where
             .await?;
 
         let mut net_ok = false;
-        let mut uboot = UbootShell::new(tx, rx).await?;
+        let shell_timeout =
+            timeout_duration(self.config.timeout).unwrap_or(DEFAULT_UBOOT_SHELL_TIMEOUT);
+        info!("Waiting for U-Boot shell response (timeout: {shell_timeout:?})...");
+        let mut uboot = new_uboot_shell(tx, rx, shell_timeout).await?;
         uboot.set_env("autoload", "yes").await?;
 
         if let Some(ref cmds) = self.config.uboot_cmd {
@@ -1601,6 +1619,7 @@ mod tests {
 
     use async_trait::async_trait;
     use tokio::io::AsyncWrite;
+    use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
     use super::{
         LocalBackend, LocalUbootConfig, Net, RemoteBackend, ResolvedRuntime, RunnerBackend,
@@ -2381,6 +2400,28 @@ mod tests {
         assert_eq!(timeout_duration(None), None);
         assert_eq!(timeout_duration(Some(0)), None);
         assert_eq!(timeout_duration(Some(5)), Some(Duration::from_secs(5)));
+    }
+
+    #[tokio::test]
+    async fn uboot_shell_initialization_times_out_without_serial_response() {
+        let (host, _peer) = tokio::io::duplex(64);
+        let (rx, tx) = tokio::io::split(host);
+        let result = tokio::time::timeout(
+            Duration::from_millis(50),
+            super::new_uboot_shell(tx.compat_write(), rx.compat(), Duration::from_millis(10)),
+        )
+        .await;
+
+        let error = match result {
+            Ok(Err(error)) => error,
+            Ok(Ok(_)) => panic!("U-Boot shell unexpectedly initialized"),
+            Err(_) => panic!("U-Boot shell initialization did not return a bounded error"),
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("timed out waiting for U-Boot shell")
+        );
     }
 
     #[test]

--- a/ostool/tests/ui/fail_qemu_override.stderr
+++ b/ostool/tests/ui/fail_qemu_override.stderr
@@ -2,4 +2,6 @@ error[E0432]: unresolved import `ostool::build::CargoQemuOverrideArgs`
  --> tests/ui/fail_qemu_override.rs:1:5
   |
 1 | use ostool::build::CargoQemuOverrideArgs;
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `CargoQemuOverrideArgs` in `build`
+  |     ^^^^^^^^^^^^^^^---------------------
+  |                    |
+  |                    no `CargoQemuOverrideArgs` in `build`


### PR DESCRIPTION
## 问题

关联 tgoskits#1666 最新评论中的 board runner 卡死。Actions run `33604193294` 使用 ostool v0.27.2，已成功分配 `OrangePi-5-Plus-1`，随后停在 `Waiting for remote board to power on through ostool-server...` 之后；调用链进入 `UbootShell::new`，其 `wait_for_interrupt` 只按字节读取并无限等待 `<INTERRUPT>`，因此 `Run command` 长时间没有后续输出。

现场验证表明 ostool-server 返回资源占用时的 HTTP 409 是正常冲突语义，不是该次卡死的根因。远端服务当前为 v0.5.0，API、session、serial websocket 均正常；使用当前 server 和 `OrangePi-5-Plus-1` 做原始串口探针，发送 `0x03` 后约 1.9 秒收到 `=> <INTERRUPT>`，因此无法从历史日志证明具体是继电器、板卡当时状态还是一次性串口时序故障。能够确定的源头问题是客户端在任何串口无响应时没有总截止时间。

## 改动

- 为 U-Boot shell 初始化增加总超时；使用配置中的正 timeout，否则使用 300 秒默认上限。
- 超时错误包含明确阶段和时长，避免 runner 无限占用。
- 初始化前输出等待阶段和实际 timeout。
- 增加黑洞串口的确定性回归测试，并记录 Unreleased changelog。
- 修复 stable Clippy 报告的冗余字段模式，并同步当前 stable rustc 的 compile-fail 诊断快照，恢复完整 CI。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --target x86_64-unknown-linux-gnu --all-features`
- `cargo build --target x86_64-unknown-linux-gnu --all-features`
- `cargo test --target x86_64-unknown-linux-gnu -- --nocapture`（全工作区通过；ostool 312 + 2 + 21，ostool-server 102 + 3，trybuild 6/6）
- `cargo publish --workspace --dry-run --locked`

Refs: rcore-os/tgoskits#1666
