### PR TITLE
fix(ostool-server): isolate serial and websocket I/O with bounded queues

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -158,6 +158,8 @@ ostool board run --package paging-test --bin basic
 ```
 
 > Exit shortcut: In the serial terminal (e.g., `ostool run uboot`), press `Ctrl+A` then `x` to quit; the tool captures this sequence and exits gracefully instead of sending it to the target device.
+
+Serial sessions isolate serial and WebSocket I/O with bounded channels. Each binary or decoded `tx` command is limited to 256 KiB; queue overflow fails the session instead of silently dropping bytes. See [server serial transport](ostool-server/README.md#serial-transport).
 > For more keyboard mappings, see `ostool/src/sterm/mod.rs`.
 
 ## ⚙️ Configuration Files

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ ostool board run --package paging-test --bin basic
 ```
 
 > 交互退出：在串口终端（如 `ostool run uboot`）中，按下 `Ctrl+A` 后再按 `x`，工具会检测到该序列并优雅退出，不会将按键发送到目标设备。
+
+串口会话通过有界通道隔离串口与 WebSocket 的收发。单条二进制或解码后的 `tx` 命令上限为 256 KiB；队列满时会话明确失败，不静默丢字节。详见 [服务器串口传输说明](ostool-server/README.md#serial-transport)。
 > 更多键盘快捷键映射可参考源码 `ostool/src/sterm/mod.rs`。
 
 ## ⚙️ 配置文件

--- a/ostool-server/README.md
+++ b/ostool-server/README.md
@@ -9,6 +9,23 @@ It provides:
 - TFTP session file handling
 - a systemd-friendly deployment model on Linux
 
+## Serial transport
+
+Serial receive, serial transmit, WebSocket receive, and WebSocket transmit run as
+independently polled asynchronous workers. Bounded channels separate the transports;
+a blocked network write does not stop serial reads, and a blocked serial write does
+not stop output or close handling. All workers belong to the session and are cancelled
+before the port is reunited and released.
+
+Each data queue holds at most 64 chunks of 4 KiB (256 KiB). Binary and decoded `tx`
+commands must fit within 256 KiB; larger commands must be split by the client. A full
+queue ends the session with an error instead of silently dropping bytes. The error
+is sent when the WebSocket remains writable; otherwise the connection closes.
+Normal serial EOF drains queued output first. Session cancellation discards pending
+commands and stops forwarding output. Serial writes do not call blocking `tcdrain`;
+close waits up to one second for the driver output queue, then clears buffers even
+if the transmitter remains stuck. This close deadline does not extend test timeouts.
+
 ## Install
 
 Before installing `ostool-server`, make sure `Node.js` and `pnpm` are available in your environment.

--- a/ostool-server/src/serial.rs
+++ b/ostool-server/src/serial.rs
@@ -1,3 +1,4 @@
 pub mod discovery;
 pub mod network;
+mod transport;
 pub mod ws;

--- a/ostool-server/src/serial/transport.rs
+++ b/ostool-server/src/serial/transport.rs
@@ -1,0 +1,392 @@
+//! Scoped serial/WebSocket workers. No worker may wait for another transport's I/O.
+
+use std::future::pending;
+
+use anyhow::Context;
+use axum::extract::ws::Message;
+use futures_util::{Sink, SinkExt, Stream, StreamExt};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite},
+    sync::{mpsc, watch},
+};
+
+use super::ws::{ClientControlMessage, decode_serial_payload};
+
+// Bound memory in bytes as well as messages. At 1.5 Mbaud the output queue holds
+// up to 1.7 seconds of traffic; a persistently stalled consumer ends the session.
+const CHUNK_SIZE: usize = 4096;
+const QUEUE_CHUNKS: usize = 64;
+const CONTROL_MESSAGES: usize = 8;
+pub(super) const MAX_COMMAND_SIZE: usize = CHUNK_SIZE * QUEUE_CHUNKS;
+
+pub(super) async fn run<R, W, S, I, E, F, H>(
+    serial_rx: &mut R,
+    serial_tx: &mut W,
+    ws_sender: &mut S,
+    ws_receiver: &mut I,
+    mut ready: watch::Receiver<bool>,
+    heartbeat: F,
+) -> anyhow::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+    S: Sink<Message> + Unpin,
+    S::Error: std::error::Error + Send + Sync + 'static,
+    I: Stream<Item = Result<Message, E>> + Unpin,
+    E: std::error::Error + Send + Sync + 'static,
+    F: Fn() -> H,
+    H: Future<Output = ()>,
+{
+    let (output_tx, mut output_rx) = mpsc::channel(QUEUE_CHUNKS);
+    let (input_tx, mut input_rx) = mpsc::channel::<Vec<u8>>(QUEUE_CHUNKS);
+    let (control_tx, mut control_rx) = mpsc::channel(CONTROL_MESSAGES);
+
+    let read_serial = async {
+        let mut buffer = [0; CHUNK_SIZE];
+        loop {
+            let size = serial_rx
+                .read(&mut buffer)
+                .await
+                .context("serial read failed")?;
+            if size == 0 {
+                // Let the WebSocket writer drain queued final bytes before ending.
+                drop(output_tx);
+                return pending::<anyhow::Result<()>>().await;
+            }
+            output_tx.try_send(buffer[..size].to_vec()).map_err(|_| {
+                anyhow::anyhow!("serial output buffer full or closed; websocket cannot keep up")
+            })?;
+            tokio::task::yield_now().await;
+        }
+    };
+    let write_websocket = async {
+        ws_sender
+            .send(Message::Text(r#"{"type":"opened"}"#.into()))
+            .await?;
+        loop {
+            let message = tokio::select! {
+                output = output_rx.recv() => {
+                    let Some(output) = output else { return Ok::<(), anyhow::Error>(()); };
+                    Message::Binary(output.into())
+                }
+                Some(control) = control_rx.recv() => control,
+            };
+            ws_sender
+                .send(message)
+                .await
+                .context("failed to send serial output over websocket")?;
+            heartbeat().await;
+        }
+    };
+    let read_websocket = async {
+        ready
+            .wait_for(|ready| *ready)
+            .await
+            .context("power-on cancelled")?;
+        while let Some(message) = ws_receiver.next().await {
+            let payload = match message? {
+                Message::Binary(bytes) => Some(bytes.to_vec()),
+                Message::Text(text) => {
+                    let control: ClientControlMessage = serde_json::from_str(&text)?;
+                    match control.kind.as_str() {
+                        "close" => return Ok::<(), anyhow::Error>(()),
+                        "tx" => Some(decode_serial_payload(control)?),
+                        other => anyhow::bail!("unsupported websocket control type `{other}`"),
+                    }
+                }
+                Message::Close(_) => return Ok(()),
+                Message::Ping(payload) => {
+                    control_tx
+                        .try_send(Message::Pong(payload))
+                        .context("websocket control buffer full or closed")?;
+                    None
+                }
+                Message::Pong(_) => None,
+            };
+            if let Some(payload) = payload {
+                anyhow::ensure!(
+                    payload.len() <= MAX_COMMAND_SIZE,
+                    "serial command too large"
+                );
+                let chunks = payload.len().div_ceil(CHUNK_SIZE);
+                // Single producer: reserve the entire command before publishing its first byte.
+                anyhow::ensure!(chunks <= input_tx.capacity(), "serial command buffer full");
+                for chunk in payload.chunks(CHUNK_SIZE) {
+                    input_tx
+                        .try_send(chunk.to_vec())
+                        .context("serial command buffer closed")?;
+                }
+            }
+            heartbeat().await;
+            tokio::task::yield_now().await;
+        }
+        Ok(())
+    };
+    let write_serial = async {
+        while let Some(payload) = input_rx.recv().await {
+            // SerialStream writes directly to the kernel. flush() calls blocking
+            // tcdrain(), holding tokio::io::split's mutex and preventing reads.
+            super::ws::write_serial_payload(serial_tx, &payload)
+                .await
+                .context("serial write failed")?;
+        }
+        Ok::<(), anyhow::Error>(())
+    };
+
+    // These futures borrow the transports, so cancellation drops every worker
+    // before the caller can reunite/close the serial port. Nothing is detached.
+    tokio::select! {
+        result = read_serial => result,
+        result = write_websocket => result,
+        result = read_websocket => result,
+        result = write_serial => result,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::{Sink, stream};
+    use std::{
+        io,
+        pin::Pin,
+        sync::Arc,
+        task::{Context, Poll},
+        time::Duration,
+    };
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        sync::{Notify, mpsc, watch},
+    };
+
+    struct OutputSink {
+        output: mpsc::UnboundedSender<Message>,
+        gate: Option<tokio::sync::oneshot::Receiver<()>>,
+        blocked: Arc<Notify>,
+    }
+
+    impl Sink<Message> for OutputSink {
+        type Error = io::Error;
+        fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            if let Some(gate) = self.gate.as_mut() {
+                if Pin::new(gate).poll(cx).is_pending() {
+                    self.blocked.notify_one();
+                    return Poll::Pending;
+                }
+                self.gate = None;
+            }
+            Poll::Ready(Ok(()))
+        }
+        fn start_send(self: Pin<&mut Self>, item: Message) -> io::Result<()> {
+            self.output.send(item).map_err(io::Error::other)
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    async fn deadline<T>(future: impl Future<Output = T>) -> T {
+        tokio::time::timeout(Duration::from_secs(2), future)
+            .await
+            .expect("transport stopped making progress")
+    }
+
+    #[tokio::test]
+    async fn blocked_websocket_does_not_stop_serial_receive_and_eof_drains() {
+        let (mut board, server) = tokio::io::duplex(64);
+        let (mut rx, mut tx) = tokio::io::split(server);
+        let (output, mut received) = mpsc::unbounded_channel();
+        let (release, gate) = tokio::sync::oneshot::channel();
+        let blocked = Arc::new(Notify::new());
+        let mut sink = OutputSink {
+            output,
+            gate: Some(gate),
+            blocked: blocked.clone(),
+        };
+        let (_ready, ready) = watch::channel(true);
+        let task = tokio::spawn(async move {
+            run(
+                &mut rx,
+                &mut tx,
+                &mut sink,
+                &mut stream::pending::<Result<Message, io::Error>>(),
+                ready,
+                || async {},
+            )
+            .await
+        });
+        deadline(blocked.notified()).await;
+        let payload: Vec<u8> = (0..1024).map(|i| i as u8).collect();
+        // More than the duplex hardware buffer: completion requires serial reads,
+        // while the WebSocket sink is provably still blocked by the gate.
+        deadline(board.write_all(&payload)).await.unwrap();
+        board.shutdown().await.unwrap();
+        release.send(()).unwrap();
+        deadline(task).await.unwrap().unwrap();
+        let mut bytes = Vec::new();
+        while let Some(message) = received.recv().await {
+            if let Message::Binary(chunk) = message {
+                bytes.extend_from_slice(&chunk);
+            }
+        }
+        assert_eq!(bytes, payload);
+    }
+
+    #[tokio::test]
+    async fn blocked_serial_write_does_not_stop_output_or_peer_close() {
+        let (mut board, server) = tokio::io::duplex(16);
+        let (mut rx, mut tx) = tokio::io::split(server);
+        let (output, mut received) = mpsc::unbounded_channel();
+        let mut sink = OutputSink {
+            output,
+            gate: None,
+            blocked: Arc::new(Notify::new()),
+        };
+        let (commands, mut command_rx) = mpsc::unbounded_channel();
+        let mut input = Box::pin(stream::poll_fn(move |cx| command_rx.poll_recv(cx)));
+        let (_ready, ready) = watch::channel(true);
+        let task = tokio::spawn(async move {
+            run(&mut rx, &mut tx, &mut sink, &mut input, ready, || async {}).await
+        });
+        commands
+            .send(Ok::<_, io::Error>(Message::Binary(vec![0x41; 128].into())))
+            .unwrap();
+        let mut first = [0; 16];
+        deadline(board.read_exact(&mut first)).await.unwrap();
+        // Leave the rest unread, so the serial writer cannot finish.
+        board.write_all(b"still alive").await.unwrap();
+        loop {
+            if let Message::Binary(bytes) = deadline(received.recv()).await.unwrap() {
+                assert_eq!(bytes.as_ref(), b"still alive");
+                break;
+            }
+        }
+        commands.send(Ok(Message::Close(None))).unwrap();
+        deadline(task).await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn output_overflow_terminates_instead_of_silently_losing_bytes() {
+        let (mut board, server) = tokio::io::duplex(CHUNK_SIZE);
+        let (mut rx, mut tx) = tokio::io::split(server);
+        let (output, _received) = mpsc::unbounded_channel();
+        let (_release, gate) = tokio::sync::oneshot::channel();
+        let mut sink = OutputSink {
+            output,
+            gate: Some(gate),
+            blocked: Arc::new(Notify::new()),
+        };
+        let (_ready, ready) = watch::channel(true);
+        let task = tokio::spawn(async move {
+            run(
+                &mut rx,
+                &mut tx,
+                &mut sink,
+                &mut stream::pending::<Result<Message, io::Error>>(),
+                ready,
+                || async {},
+            )
+            .await
+        });
+        let writer = tokio::spawn(async move {
+            board
+                .write_all(&vec![0; CHUNK_SIZE * (QUEUE_CHUNKS + 2)])
+                .await
+        });
+        let error = deadline(task).await.unwrap().unwrap_err();
+        assert!(
+            error.to_string().contains("serial output buffer full"),
+            "{error:#}"
+        );
+        let _ = deadline(writer).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn sustained_output_larger_than_queue_keeps_byte_order() {
+        let (mut board, server) = tokio::io::duplex(CHUNK_SIZE);
+        let (mut rx, mut tx) = tokio::io::split(server);
+        let (output, mut received) = mpsc::unbounded_channel();
+        let mut sink = OutputSink {
+            output,
+            gate: None,
+            blocked: Arc::new(Notify::new()),
+        };
+        let (_ready, ready) = watch::channel(true);
+        let task = tokio::spawn(async move {
+            run(
+                &mut rx,
+                &mut tx,
+                &mut sink,
+                &mut stream::pending::<Result<Message, io::Error>>(),
+                ready,
+                || async {},
+            )
+            .await
+        });
+        let payload: Vec<u8> = (0..CHUNK_SIZE * QUEUE_CHUNKS * 4)
+            .map(|i| (i % 251) as u8)
+            .collect();
+        deadline(board.write_all(&payload)).await.unwrap();
+        board.shutdown().await.unwrap();
+        deadline(task).await.unwrap().unwrap();
+        let mut bytes = Vec::new();
+        while let Some(message) = received.recv().await {
+            if let Message::Binary(chunk) = message {
+                bytes.extend_from_slice(&chunk);
+            }
+        }
+        assert_eq!(bytes, payload);
+    }
+
+    #[tokio::test]
+    async fn oversized_command_is_rejected_before_writing_any_byte() {
+        let (mut board, server) = tokio::io::duplex(64);
+        let (mut rx, mut tx) = tokio::io::split(server);
+        let (output, _received) = mpsc::unbounded_channel();
+        let mut sink = OutputSink {
+            output,
+            gate: None,
+            blocked: Arc::new(Notify::new()),
+        };
+        let (_ready, ready) = watch::channel(true);
+        let mut input = stream::iter([Ok::<_, io::Error>(Message::Binary(
+            vec![0; MAX_COMMAND_SIZE + 1].into(),
+        ))]);
+        let err = run(&mut rx, &mut tx, &mut sink, &mut input, ready, || async {})
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("serial command too large"));
+        drop(rx.unsplit(tx));
+        let mut bytes = Vec::new();
+        board.read_to_end(&mut bytes).await.unwrap();
+        assert!(bytes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancelling_workers_returns_serial_ownership() {
+        let (mut board, server) = tokio::io::duplex(64);
+        let (mut rx, mut tx) = tokio::io::split(server);
+        let (output, _received) = mpsc::unbounded_channel();
+        let (_release, gate) = tokio::sync::oneshot::channel();
+        let blocked = Arc::new(Notify::new());
+        let mut sink = OutputSink {
+            output,
+            gate: Some(gate),
+            blocked: blocked.clone(),
+        };
+        let (_ready, ready) = watch::channel(true);
+        let mut incoming = stream::pending::<Result<Message, io::Error>>();
+        tokio::select! {
+            _ = run(&mut rx, &mut tx, &mut sink, &mut incoming, ready, || async {}) => panic!("transport ended early"),
+            _ = blocked.notified() => {}
+        }
+        let mut server = rx.unsplit(tx);
+        board.write_all(b"after cancellation").await.unwrap();
+        let mut bytes = [0; 18];
+        deadline(server.read_exact(&mut bytes)).await.unwrap();
+        assert_eq!(&bytes, b"after cancellation");
+    }
+}

--- a/ostool-server/src/serial/ws.rs
+++ b/ostool-server/src/serial/ws.rs
@@ -9,7 +9,7 @@ use axum::extract::ws::{Message, WebSocket};
 use base64::Engine;
 use futures_util::{Sink, SinkExt, StreamExt};
 use serde::Deserialize;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::task::JoinHandle;
 use tokio_serial::{ClearBuffer, SerialPort, SerialPortBuilderExt};
 
@@ -21,7 +21,7 @@ use crate::{
     state::AppState,
 };
 
-const SERIAL_READ_BUFFER_SIZE: usize = 64;
+const SERIAL_CLOSE_TIMEOUT: Duration = Duration::from_secs(1);
 const SERIAL_READ_TIMEOUT: Duration = Duration::from_millis(20);
 
 enum BoardSerialStream {
@@ -73,9 +73,9 @@ impl AsyncWrite for BoardSerialStream {
 }
 
 #[derive(Debug, Deserialize)]
-struct ClientControlMessage {
+pub(super) struct ClientControlMessage {
     #[serde(rename = "type")]
-    kind: String,
+    pub(super) kind: String,
     encoding: Option<String>,
     data: Option<String>,
 }
@@ -108,7 +108,6 @@ async fn run_serial_ws_inner(
 
     let (mut ws_sender, mut ws_receiver) = socket.split();
     let (mut serial_rx, mut serial_tx) = tokio::io::split(port);
-    let mut serial_buffer = [0u8; SERIAL_READ_BUFFER_SIZE];
     let mut power_on_task = Some(spawn_power_action_task(
         state.clone(),
         board.clone(),
@@ -117,121 +116,46 @@ async fn run_serial_ws_inner(
     let power_linked = true;
     let mut shutdown_rx = session.subscribe_shutdown();
 
-    ws_sender
-        .send(Message::Text(r#"{"type":"opened"}"#.to_string().into()))
-        .await
-        .ok();
-    let result = async {
-        loop {
-            if let Some(task) = power_on_task.as_mut() {
-                tokio::select! {
-                    power_result = task => {
-                        power_on_task = None;
-                        match power_result {
-                            Ok(Ok(_)) => {}
-                            Ok(Err(err)) => {
-                                let message = format!("automatic power-on failed: {err}");
-                                log::warn!("session `{session_id}` {message}");
-                                send_power_on_failure_and_close(&mut ws_sender, &message).await;
-                                break;
-                            }
-                            Err(err) => {
-                                let message = format!("automatic power-on task join failed: {err}");
-                                log::warn!("session `{session_id}` {message}");
-                                send_power_on_failure_and_close(&mut ws_sender, &message).await;
-                                break;
-                            }
-                        }
-                    }
-                    changed = shutdown_rx.changed() => {
-                        if changed.is_ok() && *shutdown_rx.borrow() {
-                            let _ = ws_sender
-                                .send(Message::Text(r#"{"type":"closed"}"#.to_string().into()))
-                                .await;
-                            break;
-                        }
-                    }
-                    read = serial_rx.read(&mut serial_buffer) => {
-                        let read = read.context("serial read failed")?;
-                        if read == 0 {
-                            break;
-                        }
-                        ws_sender
-                            .send(Message::Binary(serial_buffer[..read].to_vec().into()))
-                            .await
-                            .context("failed to send serial output over websocket")?;
-                        let _ = session.heartbeat().await;
-                    }
-                }
-            } else {
-                tokio::select! {
-                    changed = shutdown_rx.changed() => {
-                        if changed.is_ok() && *shutdown_rx.borrow() {
-                            let _ = ws_sender
-                                .send(Message::Text(r#"{"type":"closed"}"#.to_string().into()))
-                                .await;
-                            break;
-                        }
-                    }
-                    maybe_message = ws_receiver.next() => {
-                        let Some(message) = maybe_message else {
-                            break;
-                        };
-                        match message {
-                            Ok(Message::Binary(bytes)) => {
-                                write_serial_payload(&mut serial_tx, &bytes).await?;
-                            }
-                            Ok(Message::Text(text)) => {
-                                let control: ClientControlMessage = serde_json::from_str(&text)?;
-                                match control.kind.as_str() {
-                                    "close" => {
-                                        let _ = ws_sender
-                                            .send(Message::Text(r#"{"type":"closed"}"#.to_string().into()))
-                                            .await;
-                                        break;
-                                    }
-                                    "tx" => {
-                                        let Some(data) = control.data.as_deref() else {
-                                            anyhow::bail!("missing tx data");
-                                        };
-                                        let payload = match control.encoding.as_deref() {
-                                            Some("base64") => base64::engine::general_purpose::STANDARD
-                                                .decode(data)
-                                                .context("invalid base64 payload")?,
-                                            Some("utf8") | None => data.as_bytes().to_vec(),
-                                            Some(other) => anyhow::bail!("unsupported encoding `{other}`"),
-                                        };
-                                        write_serial_payload(&mut serial_tx, &payload).await?;
-                                    }
-                                    other => anyhow::bail!("unsupported websocket control type `{other}`"),
-                                }
-                            }
-                            Ok(Message::Close(_)) => break,
-                            Ok(Message::Ping(payload)) => {
-                                ws_sender.send(Message::Pong(payload)).await.ok();
-                            }
-                            Ok(Message::Pong(_)) => {}
-                            Err(err) => return Err(err.into()),
-                        }
-                        let _ = session.heartbeat().await;
-                    }
-                    read = serial_rx.read(&mut serial_buffer) => {
-                        let read = read.context("serial read failed")?;
-                        if read == 0 {
-                            break;
-                        }
-                        ws_sender
-                            .send(Message::Binary(serial_buffer[..read].to_vec().into()))
-                            .await
-                            .context("failed to send serial output over websocket")?;
-                        let _ = session.heartbeat().await;
-                    }
-                }
-            }
+    let (ready_tx, ready_rx) = tokio::sync::watch::channel(false);
+    let result = {
+        let transport = super::transport::run(
+            &mut serial_rx,
+            &mut serial_tx,
+            &mut ws_sender,
+            &mut ws_receiver,
+            ready_rx,
+            || async {
+                let _ = session.heartbeat().await;
+            },
+        );
+        let power_on = async {
+            let result = power_on_task.as_mut().expect("power-on task exists").await;
+            power_on_task = None;
+            result
+                .context("automatic power-on task join failed")?
+                .map_err(|err| anyhow::anyhow!("automatic power-on failed: {err}"))?;
+            ready_tx.send_replace(true);
+            std::future::pending::<anyhow::Result<()>>().await
+        };
+        tokio::select! {
+            result = transport => result,
+            result = power_on => result,
+            _ = shutdown_rx.wait_for(|shutdown| *shutdown) => Ok(()),
         }
+    };
 
-        Ok(())
-    }
+    // A stalled WebSocket must not prevent session/serial cleanup. The peer
+    // sees an explicit error when writable, otherwise it sees the connection close.
+    let _ = tokio::time::timeout(SERIAL_CLOSE_TIMEOUT, async {
+        if let Err(err) = &result {
+            send_power_on_failure_and_close(&mut ws_sender, &format!("{err:#}")).await;
+        } else {
+            let _ = ws_sender
+                .send(Message::Text(r#"{"type":"closed"}"#.into()))
+                .await;
+            let _ = ws_sender.send(Message::Close(None)).await;
+        }
+    })
     .await;
 
     let result =
@@ -241,7 +165,6 @@ async fn run_serial_ws_inner(
     let _ = state
         .request_session_stop(&session_id, crate::session::SessionStopReason::SerialClosed)
         .await;
-    let _ = ws_sender.send(Message::Close(None)).await;
     result
 }
 
@@ -357,15 +280,23 @@ where
     }
 }
 
-async fn write_serial_payload<T>(
-    port: &mut tokio::io::WriteHalf<T>,
-    payload: &[u8],
-) -> anyhow::Result<()>
+pub(super) fn decode_serial_payload(control: ClientControlMessage) -> anyhow::Result<Vec<u8>> {
+    let data = control.data.context("missing tx data")?;
+    match control.encoding.as_deref() {
+        Some("base64") => base64::engine::general_purpose::STANDARD
+            .decode(data)
+            .context("invalid base64 payload"),
+        Some("utf8") | None => Ok(data.into_bytes()),
+        Some(other) => anyhow::bail!("unsupported encoding `{other}`"),
+    }
+}
+
+pub(super) async fn write_serial_payload<T>(port: &mut T, payload: &[u8]) -> anyhow::Result<()>
 where
     T: AsyncWrite + Unpin,
 {
+    // Writes are unbuffered. Do not call tcdrain while sharing the receive lock.
     port.write_all(payload).await?;
-    port.flush().await?;
     Ok(())
 }
 
@@ -378,7 +309,13 @@ trait SerialQueueCleanup {
 #[async_trait::async_trait]
 impl SerialQueueCleanup for tokio_serial::SerialStream {
     async fn flush_output(&mut self) -> std::io::Result<()> {
-        AsyncWriteExt::flush(self).await
+        // tcdrain is a blocking syscall even through tokio-serial. Observe the
+        // driver's output queue without parking a runtime worker indefinitely.
+        wait_output_empty(
+            || self.bytes_to_write().map_err(std::io::Error::from),
+            SERIAL_CLOSE_TIMEOUT,
+        )
+        .await
     }
 
     fn clear_all_buffers(&mut self) -> std::io::Result<()> {
@@ -389,7 +326,10 @@ impl SerialQueueCleanup for tokio_serial::SerialStream {
 #[async_trait::async_trait]
 impl SerialQueueCleanup for BoardSerialStream {
     async fn flush_output(&mut self) -> std::io::Result<()> {
-        AsyncWriteExt::flush(self).await
+        match self {
+            Self::Physical(stream) => stream.flush_output().await,
+            Self::Qemu(stream) => stream.flush().await,
+        }
     }
 
     fn clear_all_buffers(&mut self) -> std::io::Result<()> {
@@ -400,16 +340,38 @@ impl SerialQueueCleanup for BoardSerialStream {
     }
 }
 
+async fn wait_output_empty(
+    mut bytes_to_write: impl FnMut() -> std::io::Result<u32>,
+    timeout: Duration,
+) -> std::io::Result<()> {
+    tokio::time::timeout(timeout, async {
+        while bytes_to_write()? != 0 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "serial output queue did not drain",
+        )
+    })?
+}
+
 async fn cleanup_serial_queue_before_close<T>(port: &mut T) -> anyhow::Result<()>
 where
     T: SerialQueueCleanup + ?Sized,
 {
-    port.flush_output()
+    let drain = port
+        .flush_output()
         .await
-        .context("failed to flush serial output before close")?;
-    port.clear_all_buffers()
-        .context("failed to clear serial buffers before close")?;
-    Ok(())
+        .context("failed to drain serial output before close");
+    let clear = port
+        .clear_all_buffers()
+        .context("failed to clear serial buffers before close");
+    // Even a stuck transmitter must be purged before its lease is released.
+    drain.and(clear)
 }
 
 async fn preserve_result_after_serial_cleanup<T, P>(
@@ -534,6 +496,57 @@ mod tests {
         }
     }
 
+    struct DrainMustNotBeCalled(Vec<u8>);
+
+    impl tokio::io::AsyncRead for DrainMustNotBeCalled {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            _: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+    }
+
+    impl tokio::io::AsyncWrite for DrainMustNotBeCalled {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            bytes: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            self.0.extend_from_slice(bytes);
+            Poll::Ready(Ok(bytes.len()))
+        }
+        fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            panic!(
+                "serial payload must not synchronously drain the UART while holding the shared read/write lock"
+            );
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn serial_payload_does_not_block_receive_on_uart_drain() {
+        let (rx, mut tx) = tokio::io::split(DrainMustNotBeCalled(Vec::new()));
+        super::write_serial_payload(&mut tx, b"command\n")
+            .await
+            .unwrap();
+        assert_eq!(rx.unsplit(tx).0, b"command\n");
+    }
+
+    #[tokio::test]
+    async fn serial_close_drain_is_bounded() {
+        let err = super::wait_output_empty(|| Ok(1), Duration::ZERO)
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        super::wait_output_empty(|| Ok(0), Duration::from_secs(1))
+            .await
+            .unwrap();
+    }
+
     #[test]
     fn control_message_parses_close_type() {
         let message: ClientControlMessage = serde_json::from_str(r#"{"type":"close"}"#).unwrap();
@@ -607,6 +620,27 @@ mod tests {
             events.lock().unwrap().as_slice(),
             &[CleanupEvent::Flush, CleanupEvent::ClearAll]
         );
+    }
+
+    #[tokio::test]
+    async fn serial_cleanup_clears_buffers_even_when_drain_fails() {
+        struct StuckTransmitter(bool);
+        #[async_trait::async_trait]
+        impl SerialQueueCleanup for StuckTransmitter {
+            async fn flush_output(&mut self) -> io::Result<()> {
+                Err(io::Error::new(io::ErrorKind::TimedOut, "stuck transmitter"))
+            }
+            fn clear_all_buffers(&mut self) -> io::Result<()> {
+                self.0 = true;
+                Ok(())
+            }
+        }
+        let mut port = StuckTransmitter(false);
+        let err = cleanup_serial_queue_before_close(&mut port)
+            .await
+            .unwrap_err();
+        assert!(port.0, "failed drain must not skip purging queued commands");
+        assert!(err.to_string().contains("failed to drain serial output"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 问题与证据

排查 rcore-os/tgoskits#2357 的 OrangePi `native-hardware-smoke` 超时时，发现板卡 shell 和 NPU 命令仍能正常完成，但串口日志出现 NUL、截断和成功标记缺失。同一问题也出现在 TGOSKits `dev` 基线。

服务主机上实测：`TIOCINQ` 接收队列达到 4095 字节，FTDI `TIOCGICOUNT.overrun` 从 288 增至 298；期间 frame/parity 没有新增。旧服务器在同一个循环中读取 64 字节后等待 WebSocket 发送、会话心跳，并在串口写入后调用 `flush()`。`tokio-serial` 的 `poll_flush` 底层同步调用 `tcdrain`，还持有 `tokio::io::split` 的共享锁。上述等待都会使接收停止推进。

这证明了服务端接收链路存在丢失及阻塞边界；尚不能仅凭计数把每次现场暂停归因于某一个具体 await。

## 改动及原因

- 将串口 RX/TX、WebSocket RX/TX 拆成四个独立推进的异步循环，用有界通道隔离两种传输。采用借用式结构化并发，由会话统一取消全部循环，再合并、清理和释放串口，避免遗留后台任务或串口引用。
- 每个数据通道最多 64 个 4 KiB 数据块；队列满时明确失败，不静默丢字节。单条 binary 或解码后的 `tx` 命令限制为 256 KiB，整条检查后再入队，避免容量不足时只提交半条命令。
- 运行期写入不调用阻塞式 `tcdrain`。关闭时以非阻塞查询观察发送队列，最多等 1 秒，超时也清除残留命令。WebSocket 关闭通知同样不能无限阻止租约回收。
- 串口正常 EOF 先发送完已排队数据；会话取消立即停止转发和未完成命令。首次上电完成前仍不向串口提交客户端命令。
- 更新中英文说明，记录缓冲上限、失败行为和关闭语义。未调整硬件测试超时、波特率、流控或成功匹配规则。

## 验证

- 确定性红绿：旧 `write_serial_payload` 在禁止进入 UART drain 的同一回归中失败；移除运行期 drain 后通过。
- 定向覆盖：阻塞 WebSocket 时继续接收串口、阻塞串口 TX 时继续输出及处理关闭、EOF 保留包括 NUL 在内的原始字节、超出缓冲容量的持续输出保持顺序、溢出显式报错、超大命令零字节提交、取消归还串口所有权、排空失败仍清理缓冲。
- `cargo test -p ostool-server`：143 项单元测试、3 项真实 PTY/WebSocket 生命周期测试通过。
- `cargo clippy -p ostool-server --target x86_64-unknown-linux-gnu --all-features`、`cargo fmt --all -- --check`、release 构建通过。
- 等现有板卡会话全部释放后，已替换测试服务器二进制；保留原二进制备份，未改配置和 systemd unit。
- 同一 OrangePi-5-Plus-3、原始内核及原始 `native-hardware-smoke` 连续三轮通过（68.37、95.43、95.29 秒）：首轮接收队列采样峰值 992 字节，后两轮合并峰值 496 字节；overrun/frame/parity 增量均为 0，三份日志 NUL 数均为 0。一次通过不足以证明所有历史停滞；这里同时保留原失败的计数证据及修复后的连续观测。

- 正式 `cargo xtask starry test board --board orangepi-5-plus --test-case native-network-smoke` 同板卡通过（51.14 秒），队列峰值 496 字节、overrun/frame/parity 增量及日志 NUL 均为 0。首次直接运行板卡入口因缺少预上传会话文件在启动前退出，未计为板卡失败或通过；随后使用测试入口准备依赖并完整执行。

精确提交 `4a873173f922947919d0de39e73988cdf5b272da` 的 [push CI](https://github.com/drivercraft/ostool/actions/runs/34573796698) 和 [PR CI](https://github.com/drivercraft/ostool/actions/runs/34574070725) 均 completed/success，覆盖完整工作区 clippy、构建、测试、Web UI 单元与集成测试、publish dry run。
