### PR TITLE
fix(ostool-server): isolate physical serial receive from the network executor

### DIFF
--- a/ostool-server/README.md
+++ b/ostool-server/README.md
@@ -11,11 +11,17 @@ It provides:
 
 ## Serial transport
 
-Serial receive, serial transmit, WebSocket receive, and WebSocket transmit run as
-independently polled asynchronous workers. Bounded channels separate the transports;
-a blocked network write does not stop serial reads, and a blocked serial write does
-not stop output or close handling. All workers belong to the session and are cancelled
-before the port is reunited and released.
+On Unix, a dedicated thread drains physical serial input independently of the
+HTTP/WebSocket executor. A 256 KiB byte buffer transfers ownership to the async
+session; its short mutex protects only memory copies, never serial or network I/O.
+This also covers executor stalls caused by synchronous management operations.
+The remaining serial/WebSocket directions use independently polled async workers
+and bounded channels. QEMU serial streams continue using their async transport.
+
+Closing or cancelling a session signals and joins the physical reader before the
+port and board lease can be reused. The reader never waits for buffer capacity;
+its only blocking wait is a serial read with a 20 ms timeout. Overflow is reported
+after the already buffered bytes, instead of silently losing data.
 
 Each data queue holds at most 64 chunks of 4 KiB (256 KiB). Binary and decoded `tx`
 commands must fit within 256 KiB; larger commands must be split by the client. A full

--- a/ostool-server/src/serial.rs
+++ b/ostool-server/src/serial.rs
@@ -2,3 +2,6 @@ pub mod discovery;
 pub mod network;
 mod transport;
 pub mod ws;
+
+#[cfg(unix)]
+mod physical;

--- a/ostool-server/src/serial/physical.rs
+++ b/ostool-server/src/serial/physical.rs
@@ -1,0 +1,157 @@
+//! Physical RX keeps draining even when the HTTP/WebSocket executor is busy.
+
+use std::{
+    collections::VecDeque,
+    io::{self, Read},
+    pin::Pin,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    task::{Context, Poll},
+    thread::JoinHandle,
+    time::Duration,
+};
+
+use futures_util::task::AtomicWaker;
+use serialport::{ClearBuffer, SerialPort, TTYPort};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+const CHUNK_SIZE: usize = 4096;
+const QUEUE_BYTES: usize = CHUNK_SIZE * 64;
+const READ_TIMEOUT: Duration = Duration::from_millis(20);
+
+#[derive(Default)]
+struct ReceiveState {
+    bytes: VecDeque<u8>,
+    closed: bool,
+    error: Option<io::Error>,
+}
+
+#[derive(Default)]
+struct ReceiveBuffer {
+    state: Mutex<ReceiveState>,
+    waker: AtomicWaker,
+    stopped: AtomicBool,
+}
+
+pub(super) struct PhysicalSerial {
+    pub(super) writer: tokio_serial::SerialStream,
+    receive: Arc<ReceiveBuffer>,
+    reader: Option<JoinHandle<()>>,
+}
+
+impl PhysicalSerial {
+    pub(super) fn new(mut port: TTYPort) -> io::Result<Self> {
+        port.set_timeout(READ_TIMEOUT)?;
+        port.clear(ClearBuffer::Input)?;
+        let writer = port.try_clone_native()?.try_into()?;
+        let receive = Arc::new(ReceiveBuffer::default());
+        let shared = receive.clone();
+        let reader = std::thread::Builder::new()
+            .name("serial-rx".into())
+            .spawn(move || {
+                let mut buffer = [0; CHUNK_SIZE];
+                let error = loop {
+                    if shared.stopped.load(Ordering::Acquire) {
+                        break None;
+                    }
+                    match port.read(&mut buffer) {
+                        Ok(0) => break None,
+                        Ok(size) => {
+                            let mut state = shared.state.lock().expect("serial RX mutex poisoned");
+                            if size > QUEUE_BYTES - state.bytes.len() {
+                                break Some(io::Error::other("physical serial RX buffer full"));
+                            }
+                            state.bytes.extend(&buffer[..size]);
+                            drop(state);
+                            shared.waker.wake();
+                        }
+                        Err(error)
+                            if matches!(
+                                error.kind(),
+                                io::ErrorKind::TimedOut
+                                    | io::ErrorKind::WouldBlock
+                                    | io::ErrorKind::Interrupted
+                            ) => {}
+                        Err(error) => break Some(error),
+                    }
+                };
+                let mut state = shared.state.lock().expect("serial RX mutex poisoned");
+                state.error = error;
+                state.closed = true;
+                drop(state);
+                shared.waker.wake();
+            })?;
+        Ok(Self {
+            writer,
+            receive,
+            reader: Some(reader),
+        })
+    }
+
+    pub(super) fn stop_reader(&mut self) {
+        self.receive.stopped.store(true, Ordering::Release);
+        if let Some(reader) = self.reader.take() {
+            // Never wait for queue capacity or network I/O. The worker's only
+            // blocking operation is the finite serial read timeout. Join before
+            // releasing the lease, including cancellation, to prevent an old
+            // reader consuming bytes from the next owner's session.
+            if reader.join().is_err() {
+                log::error!("physical serial receive worker panicked");
+            }
+        }
+    }
+}
+
+impl Drop for PhysicalSerial {
+    fn drop(&mut self) {
+        self.stop_reader();
+    }
+}
+
+impl AsyncRead for PhysicalSerial {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if output.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        // Register before inspecting state; producer publication and wake cannot
+        // be lost between an empty check and returning Pending.
+        self.receive.waker.register(cx.waker());
+        let mut state = self.receive.state.lock().expect("serial RX mutex poisoned");
+        if !state.bytes.is_empty() {
+            let size = output.remaining().min(state.bytes.len());
+            let (first, second) = state.bytes.as_slices();
+            let first_size = size.min(first.len());
+            output.put_slice(&first[..first_size]);
+            output.put_slice(&second[..size - first_size]);
+            state.bytes.drain(..size);
+            return Poll::Ready(Ok(()));
+        }
+        if state.closed {
+            return Poll::Ready(state.error.take().map_or(Ok(()), Err));
+        }
+        Poll::Pending
+    }
+}
+
+impl AsyncWrite for PhysicalSerial {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bytes: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.writer).poll_write(cx, bytes)
+    }
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // Unbuffered writes: never invoke tcdrain on the network executor.
+        Poll::Ready(Ok(()))
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}

--- a/ostool-server/src/serial/ws.rs
+++ b/ostool-server/src/serial/ws.rs
@@ -11,7 +11,9 @@ use futures_util::{Sink, SinkExt, StreamExt};
 use serde::Deserialize;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::task::JoinHandle;
-use tokio_serial::{ClearBuffer, SerialPort, SerialPortBuilderExt};
+#[cfg(not(unix))]
+use tokio_serial::SerialPortBuilderExt;
+use tokio_serial::{ClearBuffer, SerialPort};
 
 use crate::{
     config::{BoardConfig, SerialConfig, SerialPortKeyKind},
@@ -24,8 +26,13 @@ use crate::{
 const SERIAL_CLOSE_TIMEOUT: Duration = Duration::from_secs(1);
 const SERIAL_READ_TIMEOUT: Duration = Duration::from_millis(20);
 
+#[cfg(unix)]
+use super::physical::PhysicalSerial;
+#[cfg(not(unix))]
+type PhysicalSerial = tokio_serial::SerialStream;
+
 enum BoardSerialStream {
-    Physical(tokio_serial::SerialStream),
+    Physical(PhysicalSerial),
     Qemu(tokio::io::DuplexStream),
 }
 
@@ -182,16 +189,24 @@ async fn open_board_serial(
     }
 
     let resolved_serial = resolve_serial_config(serial)?;
-    let port = tokio_serial::new(&resolved_serial.current_device_path, serial.baud_rate)
-        .timeout(SERIAL_READ_TIMEOUT)
-        .open_native_async()
-        .with_context(|| {
-            format!(
-                "failed to open serial port {}",
-                resolved_serial.current_device_path
-            )
-        })?;
+    let builder = tokio_serial::new(&resolved_serial.current_device_path, serial.baud_rate)
+        .timeout(SERIAL_READ_TIMEOUT);
+    #[cfg(unix)]
+    return physical_from_port(builder.open_native()?);
+    #[cfg(not(unix))]
+    let port = builder.open_native_async().with_context(|| {
+        format!(
+            "failed to open serial port {}",
+            resolved_serial.current_device_path
+        )
+    })?;
+    #[cfg(not(unix))]
     Ok(BoardSerialStream::Physical(port))
+}
+
+#[cfg(unix)]
+fn physical_from_port(port: serialport::TTYPort) -> anyhow::Result<BoardSerialStream> {
+    Ok(BoardSerialStream::Physical(PhysicalSerial::new(port)?))
 }
 
 fn spawn_power_action_task(
@@ -262,6 +277,14 @@ impl SerialOpenCleanup for tokio_serial::SerialStream {
     }
 }
 
+#[cfg(unix)]
+impl SerialOpenCleanup for PhysicalSerial {
+    fn clear_input_buffer(&mut self) -> std::io::Result<()> {
+        // Cleared before the receive worker starts, while the board is off.
+        Ok(())
+    }
+}
+
 impl SerialOpenCleanup for BoardSerialStream {
     fn clear_input_buffer(&mut self) -> std::io::Result<()> {
         match self {
@@ -320,6 +343,18 @@ impl SerialQueueCleanup for tokio_serial::SerialStream {
 
     fn clear_all_buffers(&mut self) -> std::io::Result<()> {
         self.clear(ClearBuffer::All).map_err(std::io::Error::from)
+    }
+}
+
+#[cfg(unix)]
+#[async_trait::async_trait]
+impl SerialQueueCleanup for PhysicalSerial {
+    async fn flush_output(&mut self) -> std::io::Result<()> {
+        self.stop_reader();
+        self.writer.flush_output().await
+    }
+    fn clear_all_buffers(&mut self) -> std::io::Result<()> {
+        self.writer.clear_all_buffers()
     }
 }
 
@@ -760,5 +795,89 @@ mod tests {
             other => panic!("unexpected second message: {other:?}"),
         }
         assert!(matches!(third, Message::Close(_)));
+    }
+}
+
+#[cfg(all(test, unix))]
+mod reader_progress_tests {
+    use serialport::SerialPort;
+    use std::{io::Write, time::Duration};
+    use tokio::io::AsyncReadExt;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn physical_receive_survives_a_blocked_websocket_executor() {
+        let (mut board, mut port) = serialport::TTYPort::pair().unwrap();
+        board.set_timeout(Duration::from_millis(200)).unwrap();
+        port.set_timeout(super::SERIAL_READ_TIMEOUT).unwrap();
+        let mut serial = super::physical_from_port(port).unwrap();
+        let payload: Vec<u8> = (0..65536).map(|i| (i % 251) as u8).collect();
+        let expected = payload.clone();
+        let (sent, finished) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            let result = payload
+                .chunks(128)
+                .try_for_each(|chunk| board.write_all(chunk));
+            sent.send(result).unwrap();
+            // Keep the PTY open until the receiver has consumed buffered bytes.
+            board
+        });
+        // Deliberately block the only Tokio worker. More bytes than the PTY
+        // queue can hold must be drained before this executor runs again.
+        let result = finished.recv_timeout(Duration::from_secs(2)).unwrap();
+        let _board = writer.join().unwrap();
+        assert!(
+            result.is_ok(),
+            "physical RX depends on the blocked executor: {result:?}"
+        );
+        let mut received = vec![0; expected.len()];
+        tokio::time::timeout(Duration::from_secs(2), serial.read_exact(&mut received))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(received, expected);
+    }
+    #[tokio::test(flavor = "current_thread")]
+    async fn physical_receive_overflow_is_reported_after_buffered_bytes() {
+        let (mut board, mut port) = serialport::TTYPort::pair().unwrap();
+        board.set_timeout(Duration::from_millis(200)).unwrap();
+        port.set_timeout(super::SERIAL_READ_TIMEOUT).unwrap();
+        let mut serial = super::physical_from_port(port).unwrap();
+        let writer = std::thread::spawn(move || {
+            // Deliberately exceed the receive bound without polling AsyncRead.
+            let _ = (0..4096).try_for_each(|_| board.write_all(&[0x5a; 128]));
+            board
+        });
+        let _board = writer.join().unwrap();
+        let mut bytes = Vec::new();
+        let error = tokio::time::timeout(Duration::from_secs(2), serial.read_to_end(&mut bytes))
+            .await
+            .unwrap()
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("physical serial RX buffer full"),
+            "{error}"
+        );
+        assert!(!bytes.is_empty());
+        assert!(bytes.len() <= 256 * 1024);
+        assert!(bytes.iter().all(|byte| *byte == 0x5a));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dropping_physical_receive_joins_reader_before_reusing_tty() {
+        use std::io::Read;
+        let (mut board, mut port) = serialport::TTYPort::pair().unwrap();
+        board.set_timeout(Duration::from_millis(200)).unwrap();
+        port.set_timeout(super::SERIAL_READ_TIMEOUT).unwrap();
+        let mut observer = port.try_clone_native().unwrap();
+        let mut serial = super::physical_from_port(port).unwrap();
+        board.write_all(b"first").unwrap();
+        let mut first = [0; 5];
+        serial.read_exact(&mut first).await.unwrap();
+        assert_eq!(&first, b"first");
+        drop(serial);
+        board.write_all(b"next").unwrap();
+        let mut next = [0; 4];
+        observer.read_exact(&mut next).unwrap();
+        assert_eq!(&next, b"next");
     }
 }


### PR DESCRIPTION
## 问题

#185 把串口和 WebSocket 收发拆成四个异步 future，但物理串口仍依赖 HTTP/Tokio executor。管理状态投影中的同步设备枚举以及 `ss` / `systemctl` 等同步调用会占用 worker；当 executor 无法及时推进时，四个 future 的拆分不能保证物理 RX 继续排空。

TGOSKits [板卡 CI](https://github.com/rcore-os/tgoskits/actions/runs/34585218250/job/103219203823) 在 `exec-cache` 中出现 NUL、输出截断及超时。现场现象是调查线索，尚不能单凭该日志证明每次截断都由 executor 阻塞引起。本 PR 修复的是已经通过真实 PTY 确定性复现的接收进展缺口。

## 修改

- Unix 物理 RX 由独立线程持续读取，使用 256 KiB 有界字节缓冲向异步会话传递数据；锁只保护内存复制，锁内不执行串口或网络 I/O。先登记 waker 再检查状态，避免丢失通知。
- 异步 TX 与 WebSocket 继续沿用已有传输协议。QEMU 和非 Unix 后端保持原实现。没有修改 CI、波特率、成功匹配或测试超时。
- 缓冲容量按字节约束，避免大量小读提前耗尽固定数量的消息槽。超限先保留已接收字节，再返回明确错误，不静默过滤或丢弃字节。
- 关闭或取消时先通知并 join 接收线程，再释放串口/租约。接收线程不等待网络和缓冲容量，唯一阻塞点是 20 ms 串口读取；普通输出排空仍使用既有的一秒有界清理。

## 验证

- 真实 PTY 红绿：阻塞唯一 Tokio worker，板端写入超过 PTY 内核缓冲容量的数据。旧实现稳定在 0.20 秒因写入超时失败；修复后同一用例完成并逐字节核对 64 KiB 数据。
- 真实 PTY 验证缓冲溢出错误、取消后旧 reader 已退出且不消费下一所有者的数据。
- `cargo test -p ostool-server`：146 项单元测试及 3 项会话集成测试全部通过。
- `cargo fmt --all -- --check`、`cargo clippy -p ostool-server --all-features`、release 构建、差异检查通过。
- 额外的 `--all-targets -- -D warnings` 检查遇到主线 `api/router.rs` 已有的 `items_after_test_module` 告警；未混入无关文件布局调整。

已部署到共享服务器 `10.3.10.194`，运行二进制 SHA256 为 `d195b293016a460bb9e2a9b88b1c1698f2304c3c77d65dfc3b91bc01e45c110d`。部署前确认租约已释放，保留原二进制备份。

部署后通过原始 `cargo xtask starry test board --board orangepi-5-plus`：exec-cache（2 号板）、NPU（3 号板）、网络（1 号板）3/3 全部通过，全组日志 0 NUL；各自监测区间的 overrun/frame/parity/buf_overrun 无新增。

提交 `93bc1b0` 的 [push CI](https://github.com/drivercraft/ostool/actions/runs/34589825464) 和 [PR CI](https://github.com/drivercraft/ostool/actions/runs/34589921800) 均已 completed/success。

此前 TGOSKits CI 的另一次 U-Boot DHCP 超时发生在内核入口之前，尚未建立与接收线程缺口的因果关系；重跑和部署后网络用例均通过，不将该单次现象当作本 PR 已定位的根因。
